### PR TITLE
Refactor to use a class, among other things

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_cli=false
+log_cli=true
 log_format = %(asctime)s %(levelname)-9s %(name)22s %(funcName)22s:%(lineno)-4d %(message)s
 filterwarnings =
     error

--- a/src/tiered_debug/__init__.py
+++ b/src/tiered_debug/__init__.py
@@ -1,10 +1,6 @@
 """Tiered Debugging Module"""
 
-from ._base import TieredDebug, ENVVAR, begin_end
+from ._base import TieredDebug
 
-__all__ = [
-    "TieredDebug",
-    "ENVVAR",
-    "begin_end",
-]
+__all__ = ["TieredDebug"]
 __version__ = "1.1.0"

--- a/src/tiered_debug/__init__.py
+++ b/src/tiered_debug/__init__.py
@@ -1,6 +1,15 @@
 """Tiered Debugging Module"""
 
-from ._base import set_level, set_stacklevel, lv1, lv2, lv3, lv4, lv5
+from ._base import set_level, set_stacklevel, lv1, lv2, lv3, lv4, lv5, begin_end
 
-__all__ = ["set_level", "set_stacklevel", "lv1", "lv2", "lv3", "lv4", "lv5"]
-__version__ = "1.0.0"
+__all__ = [
+    "set_level",
+    "set_stacklevel",
+    "lv1",
+    "lv2",
+    "lv3",
+    "lv4",
+    "lv5",
+    "begin_end",
+]
+__version__ = "1.1.0"

--- a/src/tiered_debug/__init__.py
+++ b/src/tiered_debug/__init__.py
@@ -1,15 +1,10 @@
 """Tiered Debugging Module"""
 
-from ._base import set_level, set_stacklevel, lv1, lv2, lv3, lv4, lv5, begin_end
+from ._base import TieredDebug, ENVVAR, begin_end
 
 __all__ = [
-    "set_level",
-    "set_stacklevel",
-    "lv1",
-    "lv2",
-    "lv3",
-    "lv4",
-    "lv5",
+    "TieredDebug",
+    "ENVVAR",
     "begin_end",
 ]
 __version__ = "1.1.0"

--- a/src/tiered_debug/_base.py
+++ b/src/tiered_debug/_base.py
@@ -1,213 +1,152 @@
-"""Module with functions to log to multiple tiered debugging levels.
-
-This module provides a way to enable multiple tiers of debug logging. It's not
-doing anything fancy, just a wrapper around a standard ``logger.debug()``
-call that caps the highest tier of debug logging to the value of ``_level``
-which can be set via the environment variable ``TIERED_DEBUG_LEVEL`` at runtime,
-with a built-in default of 1. It can be set to a value between 1 and 5. It can
-also be set interactively via the ``set_level()`` function.
-
-
-For example:
-
-.. code-block: python
-    import tiered_debugging as debug
-
-    # Set the debug level globally (optional if using environment variable)
-    debug.set_level(3)
-
-    # Log messages from any module
-    debug.lv1("This will log")  # Logs because 1 <= 3
-    debug.lv3("This will log")  # Logs because 3 <= 3
-    debug.lv4("This won't log") # Doesn't log because 4 > 3
-
-
-The ``stacklevel`` parameter is passed to the :py:func:`logging.debug()` function
-as the `stacklevel` argument. The ``stacklevel`` parameter is the stack level to
-use for the log message. The default value is 2, which means that the log message
-will appear to come from the caller of the caller each ``lv#`` function. In other
-words, if you call ``lv1()`` from a function, the log message will appear to
-come from the caller of that function. If your log formatter is set up to include
-the module name, function name, and/or line of code in the log message, having the
-stacklevel properly set will ensure the correct data is displayed.
-
-In the event that you use this module as part of another module or class, you may
-need to increase the ``stacklevel`` to 3. This can be done using the
-``set_stacklevel()`` function. This will need to be done before any logging takes
-place.
-
-Each of the lv# functions can also manually override the stacklevel:
-
-.. code-block: python
-    def lv1(self, msg: str, stklvl: t.Optional[StackLevel] = self.stacklevel) -> None:
-
-The default value of ``stklvl`` is the global ``_stacklevel`` variable, which is
-set to 2 by default.
-
-The utility is evident in the ``begin_end()`` decorator function. Since this is
-a wrapper, it adds one more level of abstraction from the calling function, which
-means that the stacklevel needs to be increased.
-"""
+"""TieredDebug class for loggging to multiple, tiered debugging levels."""
 
 # pylint: disable=C0103,W0212,W0603,W0613,W0718
 import typing as t
-from os import environ
 import sys
-from functools import wraps
+from contextlib import contextmanager
+from functools import lru_cache
 import logging
 
 DebugLevel = t.Literal[1, 2, 3, 4, 5]
+"""Type hint for the debug level."""
+
 StackLevel = t.Literal[1, 2, 3, 4, 5, 6, 7, 8, 9]  # probably overkill > 4
+"""Type hint for the stack level."""
+
+LevelKind = t.Literal["debug", "stack"]
+"""Type hint for the debug level."""
+
+MAXLEVELS = {"debug": 5, "stack": 9}
+"""Max levels for the debug and stack levels."""
+
+DEFAULTS = {"debug": 1, "stack": 3}
+"""Default levels for the debug and stack levels."""
 
 logger = logging.getLogger(__name__)
-
-ENVVAR = "TIERED_DEBUG_LEVEL"
 
 
 class TieredDebug:
     """Tiered Debug Logging Class"""
 
-    def __init__(self, level: DebugLevel = 1, stacklevel: StackLevel = 2) -> None:
+    def __init__(
+        self,
+        level: DebugLevel = DEFAULTS["debug"],
+        stacklevel: StackLevel = DEFAULTS["stack"],
+    ) -> None:
         self.level = level
         self.stacklevel = stacklevel
-        self.env_level = environ.get(ENVVAR, None)
-        if self.env_level is not None:
-            # Check if the environment variable is set and is a valid integer
-            try:
-                self.level = self.check_level(int(self.env_level))
-            except ValueError:
-                self.level = 1
 
-    def check_level(self, level: int) -> DebugLevel:
-        """Check if the level is between 1 and 5"""
-        if not 1 <= level <= 5:
-            raise ValueError("Debug level must be between 1 and 5")
-        return level
+    @property
+    def level(self) -> DebugLevel:
+        """Get the current debug level."""
+        return self._level
 
-    def set_level(self, level: DebugLevel, override: bool = False) -> None:
-        """Set :py:attr:`level` to the specified level if
+    @level.setter
+    def level(self, value: DebugLevel) -> None:
+        """Set :py:attr:`level` to the specified value if
         - The environment variable is not set
-        - The override flag is set to True
+        - self.override is set to True
 
-        :param level: The debug level (1-5).
-        :type level: DebugLevel
+        :param value: The debug level (1-5).
+        :type value: DebugLevel
         :param override: If True, override the environment variable.
         :type override: bool
-        :raises ValueError: If level is not between 1 and 5.
         """
-        if self.env_level is None or override:
-            # Either override is false and no envvar is set
-            #   or
-            # override is True
-            # If either condition is true, set the level
-            self.level = self.check_level(level)
-        # implied else is to do nothing. self.level remains unchanged
+        self._level = self.check_val(value, "debug")
 
-    def set_stacklevel(self, level: StackLevel) -> None:
-        """Set :py:attr:`stacklevel` to the specified level
+    @property
+    def stacklevel(self) -> StackLevel:
+        """Get the current stacklevel."""
+        return self._stacklevel
 
-        :param level: The stacklevel to use for the log message.
-        :type level: int
-        :raises ValueError: If level is not between 1 and 9.
+    @stacklevel.setter
+    def stacklevel(self, value: StackLevel) -> None:
+        """Set :py:attr:`stacklevel` to the specified value
+
+        :param value: The stacklevel to use for the log message.
+        :type value: int
         """
-        if not 1 <= level <= 9:
-            raise ValueError("stacklevel must be between 1 and 9")
-        self.stacklevel = level
+        self._stacklevel = self.check_val(value, "stack")
+
+    def check_val(
+        self, level: t.Union[DebugLevel, StackLevel], kind: LevelKind
+    ) -> t.Union[DebugLevel, StackLevel]:
+        """
+        Check if level is appropriate for kind. If it isn't, or is an otherwise
+        invalid type, set the default value for kind.
+
+        :param level: The debug level or stack level.
+        :type level: t.Union[DebugLevel, StackLevel]
+        :param kind: The kind of level to check.
+        :type kind: LevelKind
+        """
+        try:
+            if not 1 <= level <= MAXLEVELS[kind]:
+                raise ValueError(
+                    f"{kind} level must be between 1 and {MAXLEVELS[kind]}"
+                )
+        except Exception as exc:
+            logger.warning(
+                f'Invalid {kind} level: "{level}". Setting to {DEFAULTS[kind]}'
+            )
+            logger.debug(f"Exception: {exc}")
+            level = DEFAULTS[kind]
+        return level
+
+    @lru_cache(maxsize=128)
+    def _get_logger_name(self, level: StackLevel) -> str:
+        """Get the logger name for the specified stack level."""
+        try:
+            return sys._getframe(level).f_globals["__name__"]
+        except (ValueError, AttributeError, KeyError):
+            return "unknown"
+
+    @contextmanager
+    def change_level(self, level: DebugLevel) -> t.Generator[None, None, None]:
+        """Temporarily change the debug level within a context.
+
+        Usage:
+            with debug.level_context(3):
+                # Debug level is 3 here
+            # Debug level is restored here
+        """
+        original_level = self.level
+        self.level = level
+        try:
+            yield
+        finally:
+            self.level = original_level
+
+    def log(self, level: DebugLevel, msg: str, stklvl: StackLevel) -> None:
+        """Log a debug message at the specified level.
+        :param msg: The message to log.
+        :type msg: str
+        :param stklvl: The stacklevel to use for the log message.
+        :type stklvl: int
+        """
+        if stklvl is None:
+            stklvl = self.stacklevel
+        # Only log if the level is less than or equal to the current level
+        if level == 1 or level <= self.level:
+            logger.name = self._get_logger_name(stklvl)
+            logger.debug(f"DEBUG{level} {msg}", stacklevel=stklvl)
 
     def lv1(self, msg: str, stklvl: t.Optional[StackLevel] = None) -> None:
-        """Log a debug message at level 1.
-        :param msg: The message to log.
-        :type msg: str
-        :param stklvl: The stacklevel to use for the log message.
-        :type stklvl: int
-        """
-        if stklvl is None:
-            stklvl = self.stacklevel
-        # No condition here because this is the default level
-        # Sending stklvel - 1 here because we're already getting the calling module
-        # at level 1 and stklvel defaults to 2.
-        logger.name = sys._getframe(stklvl - 1).f_globals["__name__"]
-        logger.debug(f"DEBUG1 {msg}", stacklevel=stklvl)
+        """Log a level 1 debug message."""
+        self.log(1, msg, stklvl=stklvl)
 
     def lv2(self, msg: str, stklvl: t.Optional[StackLevel] = None) -> None:
-        """Log a debug message at level 2.
-        :param msg: The message to log.
-        :type msg: str
-        :param stklvl: The stacklevel to use for the log message.
-        :type stklvl: int
-        """
-        if stklvl is None:
-            stklvl = self.stacklevel
-        if 2 <= self.level:
-            logger.name = sys._getframe(stklvl - 1).f_globals["__name__"]
-            logger.debug(f"DEBUG2 {msg}", stacklevel=stklvl)
+        """Log a level 2 debug message."""
+        self.log(2, msg, stklvl=stklvl)
 
     def lv3(self, msg: str, stklvl: t.Optional[StackLevel] = None) -> None:
-        """Log a debug message at level 3.
-        :param msg: The message to log.
-        :type msg: str
-        :param stklvl: The stacklevel to use for the log message.
-        :type stklvl: int
-        """
-        if stklvl is None:
-            stklvl = self.stacklevel
-        if 3 <= self.level:
-            logger.name = sys._getframe(stklvl - 1).f_globals["__name__"]
-            logger.debug(f"DEBUG3 {msg}", stacklevel=stklvl)
+        """Log a level 3 debug message."""
+        self.log(3, msg, stklvl=stklvl)
 
     def lv4(self, msg: str, stklvl: t.Optional[StackLevel] = None) -> None:
-        """Log a debug message at level 4.
-        :param msg: The message to log.
-        :type msg: str
-        :param stklvl: The stacklevel to use for the log message.
-        :type stklvl: int
-        """
-        if stklvl is None:
-            stklvl = self.stacklevel
-        if 4 <= self.level:
-            logger.name = sys._getframe(stklvl - 1).f_globals["__name__"]
-            logger.debug(f"DEBUG4 {msg}", stacklevel=stklvl)
+        """Log a level 4 debug message."""
+        self.log(4, msg, stklvl=stklvl)
 
     def lv5(self, msg: str, stklvl: t.Optional[StackLevel] = None) -> None:
-        """Log a debug message at level 5.
-        :param msg: The message to log.
-        :type msg: str
-        :param stklvl: The stacklevel to use for the log message.
-        :type stklvl: int
-        """
-        if stklvl is None:
-            stklvl = self.stacklevel
-        if 5 <= self.level:
-            logger.name = sys._getframe(stklvl - 1).f_globals["__name__"]
-            logger.debug(f"DEBUG5 {msg}", stacklevel=stklvl)
-
-
-def begin_end(cls, begin: t.Optional[int] = 2, end: t.Optional[int] = 3) -> t.Callable:
-    """Decorator to log the beginning and end of a function.
-
-    This decorator will log the beginning and end of a function call at the
-    specified levels, defaulting to 2 for the beginning and 3 for the ending.
-
-    :return: The decorated function.
-    :rtype: Callable
-    """
-    mmap = {
-        1: cls.lv1,
-        2: cls.lv2,
-        3: cls.lv3,
-        4: cls.lv4,
-        5: cls.lv5,
-    }
-
-    def decorator(func: t.Callable) -> t.Callable:
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            common = f"CALL: {func.__name__}()"
-            mmap[begin](f"BEGIN {common}", stklvl=cls.stacklevel + 1)
-            result = func(*args, **kwargs)
-            mmap[end](f"END {common}", stklvl=cls.stacklevel + 1)
-            return result
-
-        return wrapper
-
-    return decorator
+        """Log a level 5 debug message."""
+        self.log(5, msg, stklvl=stklvl)

--- a/src/tiered_debug/_base.py
+++ b/src/tiered_debug/_base.py
@@ -62,24 +62,21 @@ StackLevel = t.Literal[1, 2, 3, 4, 5, 6, 7, 8, 9]  # probably overkill > 4
 logger = logging.getLogger(__name__)
 
 ENVVAR = "TIERED_DEBUG_LEVEL"
-ENV_LEVEL = environ.get(ENVVAR, None)
 
 
 class TieredDebug:
     """Tiered Debug Logging Class"""
 
     def __init__(self, level: DebugLevel = 1, stacklevel: StackLevel = 2) -> None:
+        self.level = level
         self.stacklevel = stacklevel
-        if ENV_LEVEL is not None:
+        self.env_level = environ.get(ENVVAR, None)
+        if self.env_level is not None:
             # Check if the environment variable is set and is a valid integer
             try:
-                self.check_level(int(ENV_LEVEL))
-                self.level = int(ENV_LEVEL)
+                self.level = self.check_level(int(self.env_level))
             except ValueError:
                 self.level = 1
-        else:
-            # If the environment variable is not set, use the default level
-            self.level = level
 
     def check_level(self, level: int) -> DebugLevel:
         """Check if the level is between 1 and 5"""
@@ -98,7 +95,7 @@ class TieredDebug:
         :type override: bool
         :raises ValueError: If level is not between 1 and 5.
         """
-        if ENV_LEVEL is None or override:
+        if self.env_level is None or override:
             # Either override is false and no envvar is set
             #   or
             # override is True

--- a/src/tiered_debug/debug.py
+++ b/src/tiered_debug/debug.py
@@ -1,0 +1,59 @@
+"""Sample Tiered Debugging module
+
+Clone this file into your project, then import this module wherever you need it.
+This module provides a decorator to log the beginning and end of a function or
+method call. If you notice, it *depends* on the ``debug`` object declared right
+after the import statements, but that makes it easy to use the decorator without
+having to pass the ``debug`` object around.
+
+You could add it as follows:
+
+.. code-block:: python
+    from tiered_debug import TieredDebug, begin_end
+
+    debug = TieredDebug()
+
+    @begin_end()
+    def my_function():
+        debug.lv1("This is a level 1 debug message")
+
+    my_function()
+
+"""
+
+import typing as t
+from functools import wraps
+from tiered_debug import TieredDebug
+
+debug = TieredDebug()
+
+
+def begin_end(begin: t.Optional[int] = 2, end: t.Optional[int] = 3) -> t.Callable:
+    """Decorator to log the beginning and end of a function.
+
+    This decorator will log the beginning and end of a function call at the
+    specified levels, defaulting to 2 for the beginning and 3 for the ending.
+
+    :return: The decorated function.
+    :rtype: Callable
+    """
+    mmap = {
+        1: debug.lv1,
+        2: debug.lv2,
+        3: debug.lv3,
+        4: debug.lv4,
+        5: debug.lv5,
+    }
+
+    def decorator(func: t.Callable) -> t.Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            common = f"CALL: {func.__name__}()"
+            mmap[begin](f"BEGIN {common}", stklvl=debug.stacklevel + 1)
+            result = func(*args, **kwargs)
+            mmap[end](f"END {common}", stklvl=debug.stacklevel + 1)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,9 +1,9 @@
-"""Unit tests for the base module."""
+"""Unit tests for the tiered_debug._base module."""
 
 # pylint: disable=W0212,W0603
 import logging
 import pytest
-from tiered_debug._base import TieredDebug, begin_end, ENVVAR
+from tiered_debug._base import DEFAULTS, TieredDebug, logger
 
 # Create a global instance for testing
 debug = TieredDebug()
@@ -14,310 +14,236 @@ debug = TieredDebug()
 def reset_state():
     """
     Reset the debug instance to its default values before each test.
+    Also clear any environment variables that might affect tests.
     """
     global debug
     debug = TieredDebug()
+    # Reset the logger name in case it was changed by tests
+    logger.name = __name__
 
 
-# Tests for set_level
-def test_set_level_valid():
-    """Test that set_level sets level correctly for valid inputs."""
-    debug.set_level(1)
-    assert debug.level == 1
-    debug.set_level(3)
+# Tests for level property and setter
+def test_level_property():
+    """Test that level property returns the current level."""
+    debug._level = 3
     assert debug.level == 3
-    debug.set_level(5)
-    assert debug.level == 5
 
 
-def test_set_level_invalid():
-    """Test that set_level raises ValueError for invalid inputs."""
-    with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        debug.set_level(0)
-    with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        debug.set_level(6)
+def test_level_setter_valid():
+    """Test that level setter sets level correctly for valid inputs."""
+    debug.level = 1
+    assert debug._level == 1
+    debug.level = 3
+    assert debug._level == 3
+    debug.level = 5
+    assert debug._level == 5
 
 
-def test_set_level_with_override(monkeypatch):
-    """Test that set_level with override=True overrides the environment variable."""
-    # Set environment variable
-    monkeypatch.setenv(ENVVAR, "4")
-    # Create a new instance to pick up the environment variable
-    global debug
-    debug = TieredDebug()
-    assert debug.level == 4  # Confirm env var was applied
+def test_level_setter_invalid(caplog):
+    """Test that level setter handles invalid inputs correctly."""
+    with caplog.at_level(logging.WARNING):
+        debug.level = 0
+        assert "Invalid debug level" in caplog.text
+        assert debug.level == 1  # Default value
 
-    # Override with set_level
-    debug.set_level(2, override=True)
-    assert debug.level == 2  # Should override environment variable
+    caplog.clear()
 
-    # Test with invalid level
-    with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        debug.set_level(6, override=True)
+    with caplog.at_level(logging.WARNING):
+        debug.level = 6
+        assert "Invalid debug level" in caplog.text
+        assert debug.level == 1  # Default value
 
 
-def test_set_level_without_override(monkeypatch):
-    """
-    Test that set_level with override=False doesn't override the environment variable.
-    """
-    # Set environment variable
-    monkeypatch.setenv(ENVVAR, "5")
-    # Create a new instance to pick up the environment variable
-    global debug
-    debug = TieredDebug()
-    assert debug.level == 5  # Confirm env var was applied
-
-    # Try to change without override
-    debug.set_level(2, override=False)
-    assert debug.level == 5  # Should not change because env var is set
-
-    # Try with explicit override=False
-    debug.set_level(3, override=False)
-    assert debug.level == 5  # Should still not change
-
-    # Check with invalid level (shouldn't even validate since no change happens)
-    debug.set_level(7, override=False)
-    assert debug.level == 5  # Should remain unchanged
-
-
-def test_set_level_no_env_var(monkeypatch):
-    """Test that set_level works when no environment variable is set."""
-    # Clear any environment variable
-    monkeypatch.delenv(ENVVAR, raising=False)
-    # Create a new instance
-    global debug
-    debug = TieredDebug()
-
-    # Try to set level without override when no env var exists
-    debug.set_level(3)
-    assert debug.level == 3  # Should change because no env var
-
-    # Try with explicit override=False
-    debug.set_level(4, override=False)
-    assert debug.level == 4  # Should still change
-
-
-# Tests for set_stacklevel
-def test_set_stacklevel_valid():
-    """Test that set_stacklevel sets stacklevel correctly for valid inputs."""
-    debug.set_stacklevel(1)
-    assert debug.stacklevel == 1
-    debug.set_stacklevel(2)
-    assert debug.stacklevel == 2
-    debug.set_stacklevel(3)
+# Tests for stacklevel property and setter
+def test_stacklevel_property():
+    """Test that stacklevel property returns the current stacklevel."""
+    debug._stacklevel = 3
     assert debug.stacklevel == 3
 
 
-def test_set_stacklevel_invalid():
-    """Test that set_stacklevel raises ValueError for invalid inputs."""
-    with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
-        debug.set_stacklevel(0)
-    with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
-        debug.set_stacklevel(10)
+def test_stacklevel_setter_valid():
+    """Test that stacklevel setter sets stacklevel correctly for valid inputs."""
+    debug.stacklevel = 1
+    assert debug._stacklevel == 1
+    debug.stacklevel = 3
+    assert debug._stacklevel == 3
+    debug.stacklevel = 9
+    assert debug._stacklevel == 9
 
 
-# Tests for initialization based on environment variable
-def test_initial_level_from_env(monkeypatch):
-    """Test that level is set from a valid environment variable."""
-    monkeypatch.setenv(ENVVAR, "4")
-    instance = TieredDebug()
-    assert instance.level == 4
+def test_stacklevel_setter_invalid(caplog):
+    """Test that stacklevel setter handles invalid inputs correctly."""
+    with caplog.at_level(logging.WARNING):
+        debug.stacklevel = 0
+        assert "Invalid stack level" in caplog.text
+        assert debug.stacklevel == DEFAULTS["stack"]  # Default value
+
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING):
+        debug.stacklevel = 10
+        assert "Invalid stack level" in caplog.text
+        assert debug.stacklevel == DEFAULTS["stack"]  # Default value
 
 
-def test_initial_level_invalid_env(monkeypatch):
-    """Test that level defaults to 1 with an invalid environment variable."""
-    monkeypatch.setenv(ENVVAR, "invalid")
-    instance = TieredDebug()
-    assert instance.level == 1
+# Tests for check_val method
+def test_check_val_valid():
+    """Test that check_val returns valid values unchanged."""
+    assert debug.check_val(3, "debug") == 3
+    assert debug.check_val(5, "debug") == 5
+    assert debug.check_val(3, "stack") == 3
+    assert debug.check_val(9, "stack") == 9
 
 
-def test_initial_level_out_of_range_env(monkeypatch):
-    """Test that level defaults to 1 when environment variable is out of range."""
-    monkeypatch.setenv(ENVVAR, "6")
-    instance = TieredDebug()
-    assert instance.level == 1
-    monkeypatch.setenv(ENVVAR, "0")
-    instance = TieredDebug()
-    assert instance.level == 1
+def test_check_val_invalid(caplog):
+    """Test that check_val returns default values for invalid inputs."""
+    with caplog.at_level(logging.WARNING):
+        assert debug.check_val(0, "debug") == DEFAULTS["debug"]
+        assert "Invalid debug level" in caplog.text
+
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING):
+        assert debug.check_val(10, "stack") == DEFAULTS["stack"]
+        assert "Invalid stack level" in caplog.text
 
 
-def test_initial_level_not_set(monkeypatch):
-    """Test that level defaults to 1 when environment variable is not set."""
-    monkeypatch.delenv(ENVVAR, raising=False)
-    instance = TieredDebug()
-    assert instance.level == 1
+# Tests for _get_logger_name method
+def test_get_logger_name_valid():
+    """Test that _get_logger_name returns correct module name."""
+    # For a valid stack level, it should return the module name
+    # In the code this does return sys._getframe(level).f_globals["__name__"]
+    # removing one from `level` to get the correct frame. So to get the current
+    # module name, we need to pass 1 here to get the caller's frame.
+    name = debug._get_logger_name(1)
+    assert name == __name__
 
 
-# Tests for logging functions using parametrize
+def test_get_logger_name_invalid():
+    """Test that _get_logger_name handles invalid inputs."""
+    # For an invalid stack level, it should return "unknown"
+    name = debug._get_logger_name(100)  # Too deep
+    assert name == "unknown"
+
+
+# Tests for change_level context manager
+def test_change_level():
+    """Test that change_level temporarily changes the level."""
+    debug.level = 2
+    assert debug.level == 2
+
+    with debug.change_level(4):
+        assert debug.level == 4
+
+    # After context, level should be restored
+    assert debug.level == 2
+
+
+def test_change_level_with_exception():
+    """Test that change_level restores level even if exception occurs."""
+    debug.level = 2
+
+    try:
+        with debug.change_level(4):
+            assert debug.level == 4
+            raise RuntimeError("Test exception")
+    except RuntimeError:
+        pass
+
+    # Level should be restored despite exception
+    assert debug.level == 2
+
+
+# Tests for log method
+def test_log_with_default_stacklevel():
+    """Test that log uses the default stacklevel if none provided."""
+    debug.stacklevel = DEFAULTS["stack"]
+    # Spy on _get_logger_name to check what stacklevel is passed
+    original_get_logger_name = debug._get_logger_name
+    called_with = None
+
+    def mock_get_logger_name(level):
+        nonlocal called_with
+        called_with = level
+        return original_get_logger_name(level)
+
+    debug._get_logger_name = mock_get_logger_name
+
+    try:
+        debug.log(1, "test", None)
+        assert called_with == DEFAULTS["stack"]  # Should use default stacklevel
+    finally:
+        debug._get_logger_name = original_get_logger_name
+
+
+def test_log_with_custom_stacklevel():
+    """Test that log uses the provided stacklevel."""
+    debug.stacklevel = 3
+    # Spy on _get_logger_name to check what stacklevel is passed
+    original_get_logger_name = debug._get_logger_name
+    called_with = None
+
+    def mock_get_logger_name(level):
+        nonlocal called_with
+        called_with = level
+        return original_get_logger_name(level)
+
+    debug._get_logger_name = mock_get_logger_name
+
+    try:
+        debug.log(1, "test", 4)
+        assert called_with == 4  # Should use provided stacklevel
+    finally:
+        debug._get_logger_name = original_get_logger_name
+
+
+# Tests for logging functions
 @pytest.mark.parametrize(
-    "level, should_log",
+    "debug_level,log_level,should_log",
     [
-        (1, True),
-        (2, True),
-        (3, True),
-        (4, True),
-        (5, True),
+        (1, 1, True),  # lv1 always logs
+        (1, 2, False),  # lv2 shouldn't log at debug level 1
+        (1, 3, False),  # lv3 shouldn't log at debug level 1
+        (3, 1, True),  # lv1 always logs
+        (3, 2, True),  # lv2 should log at debug level 3
+        (3, 3, True),  # lv3 should log at debug level 3
+        (3, 4, False),  # lv4 shouldn't log at debug level 3
+        (5, 1, True),  # lv1 always logs
+        (5, 5, True),  # lv5 should log at debug level 5
     ],
 )
-def test_lv1_logs(caplog, level, should_log):
-    """Test that lv1 logs messages."""
-    debug.set_level(level)
+def test_log_levels(caplog, debug_level, log_level, should_log):
+    """Test that log functions respect the current debug level."""
+    debug.level = debug_level
+
+    # Map log_level to the corresponding method
+    log_methods = {
+        1: debug.lv1,
+        2: debug.lv2,
+        3: debug.lv3,
+        4: debug.lv4,
+        5: debug.lv5,
+    }
+
+    # Clear log before test
+    caplog.clear()
+
+    # Call the appropriate log method
     with caplog.at_level(logging.DEBUG):
-        debug.lv1("Test message")
-    assert ("DEBUG1 Test message" in caplog.text) == should_log
+        log_methods[log_level](f"Test message level {log_level}")
+    if should_log:
+        assert caplog.records[0].name == __name__
+
+    # Check if the message was logged
+    expected = f"DEBUG{log_level} Test message level {log_level}"
+    assert (expected in caplog.text) == should_log
 
 
-@pytest.mark.parametrize(
-    "level, should_log",
-    [
-        (1, False),
-        (2, True),
-        (3, True),
-        (4, True),
-        (5, True),
-    ],
-)
-def test_lv2_logs(caplog, level, should_log):
-    """Test that lv2 logs messages when level >= 2."""
-    debug.set_level(level)
-    with caplog.at_level(logging.DEBUG):
-        debug.lv2("Test message")
-    assert ("DEBUG2 Test message" in caplog.text) == should_log
-
-
-@pytest.mark.parametrize(
-    "level, should_log",
-    [
-        (1, False),
-        (2, False),
-        (3, True),
-        (4, True),
-        (5, True),
-    ],
-)
-def test_lv3_logs(caplog, level, should_log):
-    """Test that lv3 logs messages when level >= 3."""
-    debug.set_level(level)
-    with caplog.at_level(logging.DEBUG):
-        debug.lv3("Test message")
-    assert ("DEBUG3 Test message" in caplog.text) == should_log
-
-
-@pytest.mark.parametrize(
-    "level, should_log",
-    [
-        (1, False),
-        (2, False),
-        (3, False),
-        (4, True),
-        (5, True),
-    ],
-)
-def test_lv4_logs(caplog, level, should_log):
-    """Test that lv4 logs messages when level >= 4."""
-    debug.set_level(level)
-    with caplog.at_level(logging.DEBUG):
-        debug.lv4("Test message")
-    assert ("DEBUG4 Test message" in caplog.text) == should_log
-
-
-@pytest.mark.parametrize(
-    "level, should_log",
-    [
-        (1, False),
-        (2, False),
-        (3, False),
-        (4, False),
-        (5, True),
-    ],
-)
-def test_lv5_logs(caplog, level, should_log):
-    """Test that lv5 logs messages when level >= 5."""
-    debug.set_level(level)
-    with caplog.at_level(logging.DEBUG):
-        debug.lv5("Test message")
-    assert ("DEBUG5 Test message" in caplog.text) == should_log
-
-
-# Tests for begin_end decorator
-def test_begin_end_decorator(caplog):
-    """Test that the begin_end decorator logs function entry and exit."""
-    debug.set_level(3)  # Set level high enough to capture both logs
-
-    # Create a decorated function
-    @begin_end(debug, begin=2, end=3)
-    def test_function():
-        return "test result"
-
-    # Call the function and capture logs
-    with caplog.at_level(logging.DEBUG):
-        result = test_function()
-
-    # Check the result and logs
-    assert result == "test result"
-    assert "DEBUG2 BEGIN CALL: test_function()" in caplog.text
-    assert "DEBUG3 END CALL: test_function()" in caplog.text
-
-
-def test_begin_end_with_custom_levels(caplog):
-    """Test that the begin_end decorator works with custom levels."""
-    debug.set_level(5)  # Set level high enough to capture both logs
-
-    # Create a decorated function with custom levels
-    @begin_end(debug, begin=4, end=5)
-    def test_function():
-        return "test result"
-
-    # Call the function and capture logs
-    with caplog.at_level(logging.DEBUG):
-        result = test_function()
-
-    # Check the result and logs
-    assert result == "test result"
-    assert "DEBUG4 BEGIN CALL: test_function()" in caplog.text
-    assert "DEBUG5 END CALL: test_function()" in caplog.text
-
-
-def test_begin_end_respects_debug_level(caplog):
-    """Test that the begin_end decorator respects the current debug level."""
-    debug.set_level(3)  # Set level to only show begin message but not end
-
-    # Create a decorated function with levels that should be partially filtered
-    @begin_end(debug, begin=3, end=4)
-    def test_function():
-        return "test result"
-
-    # Call the function and capture logs
-    with caplog.at_level(logging.DEBUG):
-        result = test_function()
-
-    # Check the result and logs
-    assert result == "test result"
-    assert "DEBUG3 BEGIN CALL: test_function()" in caplog.text
-    assert "DEBUG4 END CALL: test_function()" not in caplog.text
-
-
-# Tests for custom stacklevel parameter
-def test_custom_stacklevel_parameter(caplog):
-    """Test that the stklvl parameter affects the stacklevel used."""
-    debug.set_level(5)
-
-    # Create a function that uses a custom stacklevel
-    def inner_function():
-        debug.lv1("Custom stacklevel test", stklvl=1)
-
-    # Call and verify
-    with caplog.at_level(logging.DEBUG):
-        inner_function()
-
-    assert "Custom stacklevel test" in caplog.text
-
-
-# Tests for lv1's unconditional logging
+# Test for lv1's unconditional logging
 def test_lv1_logs_unconditionally(caplog):
     """Test that lv1 logs messages without checking debug level."""
     # Set level to minimum
-    debug.set_level(1)
+    debug.level = 1
 
     # Clear log
     caplog.clear()
@@ -332,11 +258,16 @@ def test_lv1_logs_unconditionally(caplog):
     assert "DEBUG2 Conditional message" not in caplog.text
 
 
-# Test for logger name setting in lv1
-def test_lv1_sets_logger_name(caplog):
-    """Test that lv1 sets the logger name correctly."""
-    with caplog.at_level(logging.DEBUG):
-        debug.lv1("Logger name test")
+# Tests for initialization
+def test_default_initialization():
+    """Test default initialization values."""
+    instance = TieredDebug()
+    assert instance.level == DEFAULTS["debug"]
+    assert instance.stacklevel == DEFAULTS["stack"]
 
-    # Verify the logger name is set correctly (should be this module's name)
-    assert caplog.records[0].name == __name__
+
+def test_custom_initialization():
+    """Test initialization with custom values."""
+    instance = TieredDebug(level=3, stacklevel=4)
+    assert instance.level == 3
+    assert instance.stacklevel == 4

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,9 +1,8 @@
 """Unit tests for the base module."""
 
+# pylint: disable=W0212
 import logging
 import importlib
-
-# from os import environ
 import pytest
 from tiered_debug import set_level, set_stacklevel, lv1, lv2, lv3, lv4, lv5
 import tiered_debug._base as base
@@ -40,6 +39,57 @@ def test_set_level_invalid():
         set_level(6)
 
 
+def test_set_level_with_override(monkeypatch):
+    """Test that set_level with override=True overrides the environment variable."""
+    # Set environment variable
+    monkeypatch.setenv(ENVVAR, "4")
+    importlib.reload(base)
+    assert base._level == 4  # Confirm env var was applied
+
+    # Override with set_level
+    set_level(2, override=True)
+    assert base._level == 2  # Should override environment variable
+
+    # Test with invalid level
+    with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
+        set_level(6, override=True)
+
+
+def test_set_level_without_override(monkeypatch):
+    """Test that set_level with override=False doesn't override the environment variable."""
+    # Set environment variable
+    monkeypatch.setenv(ENVVAR, "5")
+    importlib.reload(base)
+    assert base._level == 5  # Confirm env var was applied
+
+    # Try to change without override
+    set_level(2, override=False)
+    assert base._level == 5  # Should not change because env var is set
+
+    # Try with explicit override=False
+    set_level(3, override=False)
+    assert base._level == 5  # Should still not change
+
+    # Check with invalid level (shouldn't even validate since no change happens)
+    set_level(7, override=False)
+    assert base._level == 5  # Should remain unchanged
+
+
+def test_set_level_no_env_var(monkeypatch):
+    """Test that set_level works when no environment variable is set."""
+    # Clear any environment variable
+    monkeypatch.delenv(ENVVAR, raising=False)
+    importlib.reload(base)
+
+    # Try to set level without override when no env var exists
+    set_level(3)
+    assert base._level == 3  # Should change because no env var
+
+    # Try with explicit override=False
+    set_level(4, override=False)
+    assert base._level == 4  # Should still change
+
+
 # Tests for set_stacklevel
 def test_set_stacklevel_valid():
     """Test that set_stacklevel sets _stacklevel correctly for valid inputs."""
@@ -53,10 +103,10 @@ def test_set_stacklevel_valid():
 
 def test_set_stacklevel_invalid():
     """Test that set_stacklevel raises ValueError for invalid inputs."""
-    with pytest.raises(ValueError, match="stacklevel must be between 1 and 3"):
+    with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
         set_stacklevel(0)
-    with pytest.raises(ValueError, match="stacklevel must be between 1 and 3"):
-        set_stacklevel(4)
+    with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
+        set_stacklevel(10)
 
 
 # Tests for initialization based on environment variable
@@ -180,3 +230,132 @@ def test_lv5_logs(caplog, level, should_log):
     with caplog.at_level(logging.DEBUG):
         lv5("Test message")
     assert ("DEBUG5 Test message" in caplog.text) == should_log
+
+
+# Tests for fmap function
+def test_fmap_returns_correct_mapping():
+    """Test that fmap returns a dictionary with the correct keys and functions."""
+    mapping = base.FMAP
+
+    # Check that the mapping has the expected keys
+    assert set(mapping.keys()) == {1, 2, 3, 4, 5}
+
+    # Check that the values are the correct functions
+    assert mapping[1].__name__ == lv1.__name__
+    assert mapping[2].__name__ == lv2.__name__
+    assert mapping[3].__name__ == lv3.__name__
+    assert mapping[4].__name__ == lv4.__name__
+    assert mapping[5].__name__ == lv5.__name__
+
+
+# Tests for begin_end decorator
+def test_begin_end_decorator(caplog):
+    """Test that the begin_end decorator logs function entry and exit."""
+    set_level(3)  # Set level high enough to capture both logs
+
+    # Create a decorated function
+    @base.begin_end(begin=2, end=3)
+    def test_function():
+        return "test result"
+
+    # Call the function and capture logs
+    with caplog.at_level(logging.DEBUG):
+        result = test_function()
+
+    # Check the result and logs
+    assert result == "test result"
+    assert "DEBUG2 BEGIN CALL: test_function()" in caplog.text
+    assert "DEBUG3 END CALL: test_function()" in caplog.text
+
+
+def test_begin_end_with_custom_levels(caplog):
+    """Test that the begin_end decorator works with custom levels."""
+    set_level(5)  # Set level high enough to capture both logs
+
+    # Create a decorated function with custom levels
+    @base.begin_end(begin=4, end=5)
+    def test_function():
+        return "test result"
+
+    # Call the function and capture logs
+    with caplog.at_level(logging.DEBUG):
+        result = test_function()
+
+    # Check the result and logs
+    assert result == "test result"
+    assert "DEBUG4 BEGIN CALL: test_function()" in caplog.text
+    assert "DEBUG5 END CALL: test_function()" in caplog.text
+
+
+def test_begin_end_respects_debug_level(caplog):
+    """Test that the begin_end decorator respects the current debug level."""
+    set_level(3)  # Set level to only show begin message but not end
+
+    # Create a decorated function with levels that should be partially filtered
+    @base.begin_end(begin=3, end=4)
+    def test_function():
+        return "test result"
+
+    # Call the function and capture logs
+    with caplog.at_level(logging.DEBUG):
+        result = test_function()
+
+    # Check the result and logs
+    assert result == "test result"
+    assert "DEBUG3 BEGIN CALL: test_function()" in caplog.text
+    assert "DEBUG4 END CALL: test_function()" not in caplog.text
+
+
+# Tests for custom stacklevel and stack index parameters
+def test_custom_stacklevel_parameter(caplog):
+    """Test that the stklvl parameter affects the stacklevel used."""
+    set_level(5)
+
+    # Create a function that uses a custom stacklevel
+    def inner_function():
+        lv1("Custom stacklevel test", stklvl=1)
+
+    # Call and verify
+    with caplog.at_level(logging.DEBUG):
+        inner_function()
+
+    assert "Custom stacklevel test" in caplog.text
+    # The logger name will be different with stacklevel=1 vs the default of 2
+    # We're primarily testing that the parameter is accepted and used
+
+
+# Tests for lv1's unconditional logging (no level check)
+def test_lv1_logs_unconditionally(caplog):
+    """Test that lv1 logs messages without checking debug level."""
+    # Store original level
+    original_level = base._level
+
+    try:
+        # Temporarily set _level to a value that would block other log levels
+        # We have to use a valid value since there are checks in set_level
+        set_level(1)
+
+        # Clear log
+        caplog.clear()
+
+        # lv1 should log regardless of level
+        with caplog.at_level(logging.DEBUG):
+            lv1("Unconditional message")
+            lv2("Conditional message")  # Should not log
+
+        # Verify lv1 logged but lv2 didn't
+        assert "DEBUG1 Unconditional message" in caplog.text
+        assert "DEBUG2 Conditional message" not in caplog.text
+    finally:
+        # Restore original level
+        base._level = original_level
+
+
+# Test for logger name setting in lv1
+def test_lv1_sets_logger_name(caplog):
+    """Test that lv1 sets the logger name correctly using _get_logger_name."""
+    with caplog.at_level(logging.DEBUG):
+        lv1("Logger name test")
+
+    # Verify the logger name is set correctly (should be this module's name)
+    assert caplog.records[0].name == __name__

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,144 +1,151 @@
 """Unit tests for the base module."""
 
-# pylint: disable=W0212
+# pylint: disable=W0212,W0603
 import logging
-import importlib
 import pytest
-from tiered_debug import set_level, set_stacklevel, lv1, lv2, lv3, lv4, lv5
-import tiered_debug._base as base
+from tiered_debug._base import TieredDebug, begin_end, ENVVAR
 
-ENVVAR = "TIERED_DEBUG_LEVEL"
+# Create a global instance for testing
+debug = TieredDebug()
 
 
-# Fixture to reset global state before each test
+# Fixture to reset the debug instance before each test
 @pytest.fixture(autouse=True)
 def reset_state():
     """
-    Reset the global _level and _stacklevel to their default values before each test.
+    Reset the debug instance to its default values before each test.
     """
-    base._level = 1
-    base._stacklevel = 2
+    global debug
+    debug = TieredDebug()
 
 
 # Tests for set_level
 def test_set_level_valid():
-    """Test that set_level sets _level correctly for valid inputs."""
-    set_level(1)
-    assert base._level == 1
-    set_level(3)
-    assert base._level == 3
-    set_level(5)
-    assert base._level == 5
+    """Test that set_level sets level correctly for valid inputs."""
+    debug.set_level(1)
+    assert debug.level == 1
+    debug.set_level(3)
+    assert debug.level == 3
+    debug.set_level(5)
+    assert debug.level == 5
 
 
 def test_set_level_invalid():
     """Test that set_level raises ValueError for invalid inputs."""
     with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        set_level(0)
+        debug.set_level(0)
     with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        set_level(6)
+        debug.set_level(6)
 
 
 def test_set_level_with_override(monkeypatch):
     """Test that set_level with override=True overrides the environment variable."""
     # Set environment variable
     monkeypatch.setenv(ENVVAR, "4")
-    importlib.reload(base)
-    assert base._level == 4  # Confirm env var was applied
+    # Create a new instance to pick up the environment variable
+    global debug
+    debug = TieredDebug()
+    assert debug.level == 4  # Confirm env var was applied
 
     # Override with set_level
-    set_level(2, override=True)
-    assert base._level == 2  # Should override environment variable
+    debug.set_level(2, override=True)
+    assert debug.level == 2  # Should override environment variable
 
     # Test with invalid level
     with pytest.raises(ValueError, match="Debug level must be between 1 and 5"):
-        set_level(6, override=True)
+        debug.set_level(6, override=True)
 
 
 def test_set_level_without_override(monkeypatch):
-    """Test that set_level with override=False doesn't override the environment variable."""
+    """
+    Test that set_level with override=False doesn't override the environment variable.
+    """
     # Set environment variable
     monkeypatch.setenv(ENVVAR, "5")
-    importlib.reload(base)
-    assert base._level == 5  # Confirm env var was applied
+    # Create a new instance to pick up the environment variable
+    global debug
+    debug = TieredDebug()
+    assert debug.level == 5  # Confirm env var was applied
 
     # Try to change without override
-    set_level(2, override=False)
-    assert base._level == 5  # Should not change because env var is set
+    debug.set_level(2, override=False)
+    assert debug.level == 5  # Should not change because env var is set
 
     # Try with explicit override=False
-    set_level(3, override=False)
-    assert base._level == 5  # Should still not change
+    debug.set_level(3, override=False)
+    assert debug.level == 5  # Should still not change
 
     # Check with invalid level (shouldn't even validate since no change happens)
-    set_level(7, override=False)
-    assert base._level == 5  # Should remain unchanged
+    debug.set_level(7, override=False)
+    assert debug.level == 5  # Should remain unchanged
 
 
 def test_set_level_no_env_var(monkeypatch):
     """Test that set_level works when no environment variable is set."""
     # Clear any environment variable
     monkeypatch.delenv(ENVVAR, raising=False)
-    importlib.reload(base)
+    # Create a new instance
+    global debug
+    debug = TieredDebug()
 
     # Try to set level without override when no env var exists
-    set_level(3)
-    assert base._level == 3  # Should change because no env var
+    debug.set_level(3)
+    assert debug.level == 3  # Should change because no env var
 
     # Try with explicit override=False
-    set_level(4, override=False)
-    assert base._level == 4  # Should still change
+    debug.set_level(4, override=False)
+    assert debug.level == 4  # Should still change
 
 
 # Tests for set_stacklevel
 def test_set_stacklevel_valid():
-    """Test that set_stacklevel sets _stacklevel correctly for valid inputs."""
-    set_stacklevel(1)
-    assert base._stacklevel == 1
-    set_stacklevel(2)
-    assert base._stacklevel == 2
-    set_stacklevel(3)
-    assert base._stacklevel == 3
+    """Test that set_stacklevel sets stacklevel correctly for valid inputs."""
+    debug.set_stacklevel(1)
+    assert debug.stacklevel == 1
+    debug.set_stacklevel(2)
+    assert debug.stacklevel == 2
+    debug.set_stacklevel(3)
+    assert debug.stacklevel == 3
 
 
 def test_set_stacklevel_invalid():
     """Test that set_stacklevel raises ValueError for invalid inputs."""
     with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
-        set_stacklevel(0)
+        debug.set_stacklevel(0)
     with pytest.raises(ValueError, match="stacklevel must be between 1 and 9"):
-        set_stacklevel(10)
+        debug.set_stacklevel(10)
 
 
 # Tests for initialization based on environment variable
 def test_initial_level_from_env(monkeypatch):
-    """Test that _level is set from a valid environment variable."""
+    """Test that level is set from a valid environment variable."""
     monkeypatch.setenv(ENVVAR, "4")
-    importlib.reload(base)
-    assert base._level == 4
+    instance = TieredDebug()
+    assert instance.level == 4
 
 
 def test_initial_level_invalid_env(monkeypatch):
-    """Test that _level defaults to 1 with an invalid environment variable."""
+    """Test that level defaults to 1 with an invalid environment variable."""
     monkeypatch.setenv(ENVVAR, "invalid")
-    importlib.reload(base)
-    assert base._level == 1
+    instance = TieredDebug()
+    assert instance.level == 1
 
 
 def test_initial_level_out_of_range_env(monkeypatch):
-    """Test that _level defaults to 1 when environment variable is out of range."""
+    """Test that level defaults to 1 when environment variable is out of range."""
     monkeypatch.setenv(ENVVAR, "6")
-    importlib.reload(base)
-    assert base._level == 1
+    instance = TieredDebug()
+    assert instance.level == 1
     monkeypatch.setenv(ENVVAR, "0")
-    importlib.reload(base)
-    assert base._level == 1
+    instance = TieredDebug()
+    assert instance.level == 1
 
 
 def test_initial_level_not_set(monkeypatch):
-    """Test that _level defaults to 1 when environment variable is not set."""
+    """Test that level defaults to 1 when environment variable is not set."""
     monkeypatch.delenv(ENVVAR, raising=False)
-    importlib.reload(base)
-    assert base._level == 1
+    instance = TieredDebug()
+    assert instance.level == 1
 
 
 # Tests for logging functions using parametrize
@@ -153,10 +160,10 @@ def test_initial_level_not_set(monkeypatch):
     ],
 )
 def test_lv1_logs(caplog, level, should_log):
-    """Test that lv1 logs messages when _level >= 1."""
-    set_level(level)
+    """Test that lv1 logs messages."""
+    debug.set_level(level)
     with caplog.at_level(logging.DEBUG):
-        lv1("Test message")
+        debug.lv1("Test message")
     assert ("DEBUG1 Test message" in caplog.text) == should_log
 
 
@@ -171,10 +178,10 @@ def test_lv1_logs(caplog, level, should_log):
     ],
 )
 def test_lv2_logs(caplog, level, should_log):
-    """Test that lv2 logs messages when _level >= 2."""
-    set_level(level)
+    """Test that lv2 logs messages when level >= 2."""
+    debug.set_level(level)
     with caplog.at_level(logging.DEBUG):
-        lv2("Test message")
+        debug.lv2("Test message")
     assert ("DEBUG2 Test message" in caplog.text) == should_log
 
 
@@ -189,10 +196,10 @@ def test_lv2_logs(caplog, level, should_log):
     ],
 )
 def test_lv3_logs(caplog, level, should_log):
-    """Test that lv3 logs messages when _level >= 3."""
-    set_level(level)
+    """Test that lv3 logs messages when level >= 3."""
+    debug.set_level(level)
     with caplog.at_level(logging.DEBUG):
-        lv3("Test message")
+        debug.lv3("Test message")
     assert ("DEBUG3 Test message" in caplog.text) == should_log
 
 
@@ -207,10 +214,10 @@ def test_lv3_logs(caplog, level, should_log):
     ],
 )
 def test_lv4_logs(caplog, level, should_log):
-    """Test that lv4 logs messages when _level >= 4."""
-    set_level(level)
+    """Test that lv4 logs messages when level >= 4."""
+    debug.set_level(level)
     with caplog.at_level(logging.DEBUG):
-        lv4("Test message")
+        debug.lv4("Test message")
     assert ("DEBUG4 Test message" in caplog.text) == should_log
 
 
@@ -225,36 +232,20 @@ def test_lv4_logs(caplog, level, should_log):
     ],
 )
 def test_lv5_logs(caplog, level, should_log):
-    """Test that lv5 logs messages when _level >= 5."""
-    set_level(level)
+    """Test that lv5 logs messages when level >= 5."""
+    debug.set_level(level)
     with caplog.at_level(logging.DEBUG):
-        lv5("Test message")
+        debug.lv5("Test message")
     assert ("DEBUG5 Test message" in caplog.text) == should_log
-
-
-# Tests for fmap function
-def test_fmap_returns_correct_mapping():
-    """Test that fmap returns a dictionary with the correct keys and functions."""
-    mapping = base.FMAP
-
-    # Check that the mapping has the expected keys
-    assert set(mapping.keys()) == {1, 2, 3, 4, 5}
-
-    # Check that the values are the correct functions
-    assert mapping[1].__name__ == lv1.__name__
-    assert mapping[2].__name__ == lv2.__name__
-    assert mapping[3].__name__ == lv3.__name__
-    assert mapping[4].__name__ == lv4.__name__
-    assert mapping[5].__name__ == lv5.__name__
 
 
 # Tests for begin_end decorator
 def test_begin_end_decorator(caplog):
     """Test that the begin_end decorator logs function entry and exit."""
-    set_level(3)  # Set level high enough to capture both logs
+    debug.set_level(3)  # Set level high enough to capture both logs
 
     # Create a decorated function
-    @base.begin_end(begin=2, end=3)
+    @begin_end(debug, begin=2, end=3)
     def test_function():
         return "test result"
 
@@ -270,10 +261,10 @@ def test_begin_end_decorator(caplog):
 
 def test_begin_end_with_custom_levels(caplog):
     """Test that the begin_end decorator works with custom levels."""
-    set_level(5)  # Set level high enough to capture both logs
+    debug.set_level(5)  # Set level high enough to capture both logs
 
     # Create a decorated function with custom levels
-    @base.begin_end(begin=4, end=5)
+    @begin_end(debug, begin=4, end=5)
     def test_function():
         return "test result"
 
@@ -289,10 +280,10 @@ def test_begin_end_with_custom_levels(caplog):
 
 def test_begin_end_respects_debug_level(caplog):
     """Test that the begin_end decorator respects the current debug level."""
-    set_level(3)  # Set level to only show begin message but not end
+    debug.set_level(3)  # Set level to only show begin message but not end
 
     # Create a decorated function with levels that should be partially filtered
-    @base.begin_end(begin=3, end=4)
+    @begin_end(debug, begin=3, end=4)
     def test_function():
         return "test result"
 
@@ -306,56 +297,46 @@ def test_begin_end_respects_debug_level(caplog):
     assert "DEBUG4 END CALL: test_function()" not in caplog.text
 
 
-# Tests for custom stacklevel and stack index parameters
+# Tests for custom stacklevel parameter
 def test_custom_stacklevel_parameter(caplog):
     """Test that the stklvl parameter affects the stacklevel used."""
-    set_level(5)
+    debug.set_level(5)
 
     # Create a function that uses a custom stacklevel
     def inner_function():
-        lv1("Custom stacklevel test", stklvl=1)
+        debug.lv1("Custom stacklevel test", stklvl=1)
 
     # Call and verify
     with caplog.at_level(logging.DEBUG):
         inner_function()
 
     assert "Custom stacklevel test" in caplog.text
-    # The logger name will be different with stacklevel=1 vs the default of 2
-    # We're primarily testing that the parameter is accepted and used
 
 
-# Tests for lv1's unconditional logging (no level check)
+# Tests for lv1's unconditional logging
 def test_lv1_logs_unconditionally(caplog):
     """Test that lv1 logs messages without checking debug level."""
-    # Store original level
-    original_level = base._level
+    # Set level to minimum
+    debug.set_level(1)
 
-    try:
-        # Temporarily set _level to a value that would block other log levels
-        # We have to use a valid value since there are checks in set_level
-        set_level(1)
+    # Clear log
+    caplog.clear()
 
-        # Clear log
-        caplog.clear()
+    # lv1 should log regardless of level
+    with caplog.at_level(logging.DEBUG):
+        debug.lv1("Unconditional message")
+        debug.lv2("Conditional message")  # Should not log
 
-        # lv1 should log regardless of level
-        with caplog.at_level(logging.DEBUG):
-            lv1("Unconditional message")
-            lv2("Conditional message")  # Should not log
-
-        # Verify lv1 logged but lv2 didn't
-        assert "DEBUG1 Unconditional message" in caplog.text
-        assert "DEBUG2 Conditional message" not in caplog.text
-    finally:
-        # Restore original level
-        base._level = original_level
+    # Verify lv1 logged but lv2 didn't
+    assert "DEBUG1 Unconditional message" in caplog.text
+    assert "DEBUG2 Conditional message" not in caplog.text
 
 
 # Test for logger name setting in lv1
 def test_lv1_sets_logger_name(caplog):
-    """Test that lv1 sets the logger name correctly using _get_logger_name."""
+    """Test that lv1 sets the logger name correctly."""
     with caplog.at_level(logging.DEBUG):
-        lv1("Logger name test")
+        debug.lv1("Logger name test")
 
     # Verify the logger name is set correctly (should be this module's name)
     assert caplog.records[0].name == __name__


### PR DESCRIPTION
Add a sample `debug.py` module to the main offering that shows how to make a persistent object available across an entire project.

Remove environment variables as they are now more hassle than they are worth.

Include a cool decorator in the sample `debug.py` file.

Update tests and the README