### PR TITLE
Release prep for 1.3.1

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changes
 - Updated ``log``, ``lv1``, ``lv2``, ``lv3``, ``lv4``, and ``lv5`` methods in ``_base.py`` to use proper default values for ``exc_info`` (``False``), ``stack_info`` (``False``), and ``stacklevel`` (``1``) instead of ``None``.
 - Corrected tests ``test_log_with_default_stacklevel`` and ``test_log_levels`` to verify that the record logger name matches the logger name assigned in the fixture, rather than a hardcoded expected value.
 - Corrected ``test_add_handler`` and ``test_log_with_default_stacklevel`` in ``test_base.py`` to add ``caplog.set_level(logging.DEBUG)`` for proper DEBUG log capture. Kudos to @schoekek for identifying the issue and supplying the fix in #6. The nice thing is that it's not a code change, but an update to how testing is done.
+- Discovered that ReadTheDocs builds were failing due to conditional resulting in ``html_theme`` being set to ``None`` when building on ReadTheDocs. Updated ``docs/conf.py`` to always set ``html_theme`` to ``sphinx_rtd_theme``, at least for now.
 
 All tests passing.
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to ``tiered-debug`` will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+[1.3.1] - 2025-10-03
+--------------------
+
+Changes
+~~~~~~~
+
+- Updated version to 1.3.1 for patch release.
+- Updated ``log``, ``lv1``, ``lv2``, ``lv3``, ``lv4``, and ``lv5`` methods in ``_base.py`` to use proper default values for ``exc_info`` (``False``), ``stack_info`` (``False``), and ``stacklevel`` (``1``) instead of ``None``.
+- Corrected tests ``test_log_with_default_stacklevel`` and ``test_log_levels`` to verify that the record logger name matches the logger name assigned in the fixture, rather than a hardcoded expected value.
+- Corrected ``test_add_handler`` and ``test_log_with_default_stacklevel`` in ``test_base.py`` to add ``caplog.set_level(logging.DEBUG)`` for proper DEBUG log capture. Kudos to @schoekek for identifying the issue and supplying the fix in #6. The nice thing is that it's not a code change, but an update to how testing is done.
+
+All tests passing.
+
+
 [1.3.0] - 2025-04-21
 --------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,10 @@ master_doc = "index"
 # -- Options for HTML output -------------------------------------------------
 
 pygments_style = "sphinx"
-html_theme = "sphinx_rtd_theme" if environ.get("READTHEDOCS") != "True" else None
+html_theme = "sphinx_rtd_theme"
+# html_theme = (
+#     "sphinx_rtd_theme" if environ.get("READTHEDOCS") != "True" else "sphinx_rtd_theme"
+)
 
 # Add "Edit Source" links into the template
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ pygments_style = "sphinx"
 html_theme = "sphinx_rtd_theme"
 # html_theme = (
 #     "sphinx_rtd_theme" if environ.get("READTHEDOCS") != "True" else "sphinx_rtd_theme"
-)
+# )
 
 # Add "Edit Source" links into the template
 html_context = {

--- a/src/tiered_debug/__init__.py
+++ b/src/tiered_debug/__init__.py
@@ -35,7 +35,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, Aaron Mildenstein"
 __license__ = "Apache 2.0"

--- a/src/tiered_debug/_base.py
+++ b/src/tiered_debug/_base.py
@@ -265,9 +265,9 @@ class TieredDebug:
         level: DebugLevel,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at the specified debug level.
@@ -323,9 +323,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 1 (always logged).
@@ -361,9 +361,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 2 (logged if level >= 2).
@@ -399,9 +399,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 3 (logged if level >= 3).
@@ -437,9 +437,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 4 (logged if level >= 4).
@@ -475,9 +475,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = None,
-        stack_info: Optional[bool] = None,
-        stacklevel: Optional[int] = None,
+        exc_info: Optional[bool] = False,
+        stack_info: Optional[bool] = False,
+        stacklevel: Optional[int] = 1,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 5 (logged if level >= 5).

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -237,6 +237,7 @@ def test_add_handler(debug, caplog):
         >>> handler in debug.logger.handlers
         True
     """
+    caplog.set_level(logging.DEBUG)
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(funcName)s:%(lineno)d %(message)s")
     debug.add_handler(handler, formatter=formatter)
@@ -504,13 +505,12 @@ def test_log_with_default_stacklevel(debug, caplog):
         >>> debug.add_handler(handler)
         >>> debug.log(1, "Test: %s", "value")
     """
+    caplog.set_level(logging.DEBUG)
     debug.stacklevel = 3
-    expected = "_pytest.python"
     with caplog.at_level(logging.DEBUG, logger=debug.logger.name):
         debug.log(1, "Test message: %s", "value")
-        assert (
-            caplog.records[0].name == expected
-        )  # In testing, stacklevel 3 points to "_pytest.python"
+        # The name should match the logger name assigned in the fixture
+        assert caplog.records[0].name == debug.logger.name
 
 
 def test_log_with_custom_stacklevel(debug, caplog):
@@ -587,7 +587,8 @@ def test_log_levels(debug, caplog, debug_level, log_level, should_log):
         expected = f"DEBUG{log_level} Test message level {log_level}: value"
         assert (expected in caplog.text) == should_log
         if should_log:
-            assert caplog.records[0].name == __name__
+            # Should match the logger name assigned in the fixture
+            assert caplog.records[0].name == debug.logger.name
 
 
 def test_lv1_logs_unconditionally(debug, caplog):


### PR DESCRIPTION
Minor updates to code and tests.

- Updated version to 1.3.1 for patch release.
- Updated `log`, `lv1`, `lv2`, `lv3`, `lv4`, and `lv5` methods in `_base.py` to use proper default values for `exc_info` (`False`), `stack_info` (`False`), and `stacklevel` (`1`) instead of `None`.
- Corrected tests `test_log_with_default_stacklevel` and `test_log_levels` to verify that the record logger name matches the logger name assigned in the fixture, rather than a hardcoded expected value.
- Corrected `test_add_handler` and `test_log_with_default_stacklevel` in `test_base.py` to add `caplog.set_level(logging.DEBUG)` for proper DEBUG log capture. Kudos to @schoekek for identifying the issue and supplying the fix in https://github.com/untergeek/tiered-debug/issues/6. The nice thing is that it's not a code change, but an update to how testing is done.
- Discovered that ReadTheDocs builds were failing due to conditional resulting in `html_theme` being set to `None` when building on ReadTheDocs. Updated `docs/conf.py` to always set `html_theme` to `sphinx_rtd_theme`, at least for now.


All tests passing.