### PR TITLE
Release 1.4.0

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,23 @@ All notable changes to ``tiered-debug`` will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+[1.4.0] - 2025-10-07
+--------------------
+
+Changes
+~~~~~~~
+
+A bit of a reversion from 1.3.1 with regards to default logger kwargs, but with a better approach.
+
+- Updated version to 1.4.0 for release.
+- Configure ``log``, ``lv1``, ``lv2``, ``lv3``, ``lv4``, and ``lv5`` methods in ``_base.py`` to use default ``None`` value for ``exc_info``, ``stack_info``, ``stacklevel``, and ``extra``. If ``None`` is provided, the logging module will apply its own defaults (``exc_info=False``, ``stack_info=False``, ``extra={}``, and then set ``stacklevel`` to the `effective` stack level).
+- Pruned unused import in ``docs/conf.py``.
+- Updated ``debug.py`` to use ``Literal[1, 2, 3, 4, 5]`` for ``begin`` and ``end`` parameters in ``begin_end`` decorator in order to match the typing in ``_base.py``. This cleans up MyPy and other linter warnings.
+- Updated ``test_base.py`` tests ``test_log_with_default_stacklevel`` and ``test_log_levels`` to collect the logger name from the fixture rather than hardcoding an expected value.
+
+All tests passing. Tested pre-release in a sample project and everything looks good.
+
+
 [1.3.1] - 2025-10-03
 --------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ Examples:
     >>> author
     'Aaron Mildenstein'
     >>> version
-    '1.3'
+    '1.4'
     >>> 'autodoc' in [ext.split('.')[-1] for ext in extensions]
     True
 """
@@ -27,7 +27,6 @@ Examples:
 # pylint: disable=C0103,E0401,W0622
 
 # -- Imports and setup -----------------------------------------------------
-from os import environ
 from tiered_debug import __author__, __copyright__, __version__
 
 # -- Project information -----------------------------------------------------

--- a/src/tiered_debug/__init__.py
+++ b/src/tiered_debug/__init__.py
@@ -35,7 +35,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, Aaron Mildenstein"
 __license__ = "Apache 2.0"

--- a/src/tiered_debug/_base.py
+++ b/src/tiered_debug/_base.py
@@ -265,9 +265,9 @@ class TieredDebug:
         level: DebugLevel,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at the specified debug level.
@@ -298,6 +298,12 @@ class TieredDebug:
         if level > self.level:
             return
 
+        if exc_info is None:
+            exc_info = False
+
+        if stack_info is None:
+            stack_info = False
+
         if extra is not None and not isinstance(extra, dict):
             raise TypeError("extra must be a dictionary or None")
 
@@ -323,9 +329,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 1 (always logged).
@@ -361,9 +367,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 2 (logged if level >= 2).
@@ -399,9 +405,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 3 (logged if level >= 3).
@@ -437,9 +443,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 4 (logged if level >= 4).
@@ -475,9 +481,9 @@ class TieredDebug:
         self,
         msg: str,
         *args,
-        exc_info: Optional[bool] = False,
-        stack_info: Optional[bool] = False,
-        stacklevel: Optional[int] = 1,
+        exc_info: Optional[bool] = None,
+        stack_info: Optional[bool] = None,
+        stacklevel: Optional[int] = None,
         extra: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Log a message at debug level 5 (logged if level >= 5).

--- a/src/tiered_debug/debug.py
+++ b/src/tiered_debug/debug.py
@@ -18,7 +18,7 @@ Examples:
 """
 
 from functools import wraps
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from ._base import TieredDebug
 
@@ -34,8 +34,8 @@ debug = TieredDebug(level=1, stacklevel=3)
 
 def begin_end(
     debug_obj: Optional[TieredDebug] = None,
-    begin: int = DEFAULT_BEGIN,
-    end: int = DEFAULT_END,
+    begin: Literal[1, 2, 3, 4, 5] = DEFAULT_BEGIN,
+    end: Literal[1, 2, 3, 4, 5] = DEFAULT_END,
     stacklevel: int = 2,
     extra: Optional[Dict[str, Any]] = None,
 ):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -507,10 +507,27 @@ def test_log_with_default_stacklevel(debug, caplog):
     """
     caplog.set_level(logging.DEBUG)
     debug.stacklevel = 3
+    expected = debug._get_logger_name(2)
+    # So why does expected look for level 2? Because the logger name is determined
+    # by the frame at the stack level from which it was called. This is confusing
+    # because log() itself calls _get_logger_name. However, when _get_logger_name
+    # is called by log(), an extra level of indirection is added because it is
+    # being called from inside log(). In other words, in order to get the correct
+    # caller, it has to go up one more level than if calling _get_logger_name
+    # from outside of log(). When debug._get_logger_name is called directly from
+    # this function, it points to the caller of debug._get_logger_name, which is
+    # the same as the caller of log(), which is why we call it with 2 here.
+    # Perhaps seeing it laid out will help:
+    # logger=debug.logger.name here is tests.test_base, this module.
+    # (this function) -> log() -> _get_logger_name() = 3
+    # (this function) -> _get_logger_name() = 2
+    # Calling _get_logger_name() only needs to go up 2 levels to get the same name
+    # as when log() is called by this function.
+    # Make sense? I hope so.
     with caplog.at_level(logging.DEBUG, logger=debug.logger.name):
         debug.log(1, "Test message: %s", "value")
-        # The name should match the logger name assigned in the fixture
-        assert caplog.records[0].name == debug.logger.name
+        # The name should match the logger name up two levels.
+        assert caplog.records[0].name == expected
 
 
 def test_log_with_custom_stacklevel(debug, caplog):
@@ -582,13 +599,25 @@ def test_log_levels(debug, caplog, debug_level, log_level, should_log):
         5: debug.lv5,
     }
 
+    expected = debug._get_logger_name(1)
+    # So why does expected look for level 1 here?
+    # It looks for 2 in test_log_with_default_stacklevel, so why 1 here?
+    # Because it's parametrized and called from within a loop, so the stack level
+    # is different. When log() is called from within lvX(), it adds an extra
+    # level of indirection, so to get the caller of lvX(), we have to go up one
+    # more level than when calling log() directly. When debug._get_logger_name is
+    # called directly from this function, it points to the caller of
+    # debug._get_logger_name, which is this function.
+    # The caller of log() is lvX(), and the caller of lvX() is this function.
+    # Therefore, we need to go up one level to get the same name as
+    # when log() is called by lvX(), which is why we call it with 1 here.
     with caplog.at_level(logging.DEBUG, logger=debug.logger.name):
         log_methods[log_level](f"Test message level {log_level}: %s", "value")
-        expected = f"DEBUG{log_level} Test message level {log_level}: value"
-        assert (expected in caplog.text) == should_log
+        msg = f"DEBUG{log_level} Test message level {log_level}: value"
+        assert (msg in caplog.text) == should_log
         if should_log:
             # Should match the logger name assigned in the fixture
-            assert caplog.records[0].name == debug.logger.name
+            assert caplog.records[0].name == expected
 
 
 def test_lv1_logs_unconditionally(debug, caplog):


### PR DESCRIPTION
A bit of a reversion from 1.3.1 with regards to default logger kwargs, but with a better approach.

- Updated version to 1.4.0 for release.
- Configure `log`, `lv1`, `lv2`, `lv3`, `lv4`, and `lv5` methods in `_base.py` to use default `None` value for `exc_info`, `stack_info`, `stacklevel`, and `extra`. If `None` is provided, the logging module will apply its own defaults (`exc_info=False`, `stack_info=False`, `extra={}`, and then set `stacklevel` to the `effective` stack level).
- Pruned unused import in `docs/conf.py`.
- Updated `debug.py` to use `Literal[1, 2, 3, 4, 5]` for `begin` and `end` parameters in `begin_end` decorator in order to match the typing in `_base.py`. This cleans up MyPy and other linter warnings.
- Updated `test_base.py` tests `test_log_with_default_stacklevel` and `test_log_levels` to collect the logger name from the fixture rather than hardcoding an expected value.

All tests passing. Tested pre-release in a sample project and everything looks good.